### PR TITLE
Remove the fixed path requirement from solution build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ glew/
 SFML-2.1/
 util/
 lzz.exe
+temp/
+compiled/
+VoxelQuest/x64/
+*.suo
+*.sdf
+GLSLFragmentLighting.opensdf

--- a/VoxelQuest/VoxelQuest.vcxproj
+++ b/VoxelQuest/VoxelQuest.vcxproj
@@ -83,7 +83,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>C:\wamp\www\voxelquestiso\glew\include;C:\wamp\www\voxelquestiso\SFML-2.1\include;C:\wamp\www\voxelquestiso\freeglut\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\glew\include;$(SolutionDir)\SFML-2.1\include;$(SolutionDir)\freeglut\include;$(IncludePath)</IncludePath>
     <LibraryPath>opengl32.lib;glu32.lib;C:\wamp\www\voxelquestiso\SFML-2.1\lib;C:\wamp\www\voxelquestiso\glew\lib\Release\x64;C:\wamp\www\voxelquestiso\freeglut\lib\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -180,13 +180,13 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\wamp\www\voxelquestiso\glew\lib;C:\Program Files %28x86%29\Windows Kits\8.0\Lib\win8\um\x64;C:\Program Files %28x86%29\Microsoft Visual Studio 11.0\VC\lib\amd64;C:\SFML-2.1\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\glew\lib;C:\Program Files %28x86%29\Windows Kits\8.0\Lib\win8\um\x64;C:\Program Files %28x86%29\Microsoft Visual Studio 11.0\VC\lib\amd64;$(SolutionDir)\SFML-2.1\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <StackReserveSize>
       </StackReserveSize>
       <AdditionalDependencies>sfml-system-s.lib;sfml-audio-s.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>../combine.bat</Command>
+      <Command>$(SolutionDir)combine.bat $(SolutionDir)</Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>../cleanup.bat;</Command>

--- a/combine.bat
+++ b/combine.bat
@@ -6,9 +6,10 @@ echo ...
 echo ...
 echo ...
 echo ...
-
-cd c:\wamp\www\voxelquestiso
 echo cleaning files
+
+cd %1
+
 del /q .\compiled\*.*
 del /q .\temp\*.*
 
@@ -16,8 +17,8 @@ del /q .\temp\*.*
 echo copying files to source
 :: -----------------------------------
 
-xcopy /s /y .\src\cpp .\temp
-xcopy /y .\lzz.exe .\temp
+xcopy /s /y /i .\src\cpp .\temp
+xcopy /y /i .\lzz.exe .\temp
 cd temp
 
 :: -----------------------------------
@@ -67,5 +68,5 @@ cd ..
 echo copying files to compiled
 :: -----------------------------------
 
-xcopy /s /y .\temp\*.e .\compiled
+xcopy /s /y /i .\temp\*.e .\compiled
 copy /b .\temp\*.h .\compiled\main.cpp


### PR DESCRIPTION
This updates combine.bat to remove hitting prompts on pre-build and updates the project file to remove the hard coded path's from IncludePath and AdditionalLibraryDirectories.

.gitignore has also been updated to filter out the additional files I had in my working directory after Resources.zip was extracted
