### PR TITLE
Compiles on Mac

### DIFF
--- a/src/cpp/f00025_includes.h
+++ b/src/cpp/f00025_includes.h
@@ -126,9 +126,16 @@ bool TRACE_ON = false;
 #include <SFML/Audio/Music.hpp>
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#include <GLUT/glut.h>
+#else
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/freeglut.h>
+#endif
+
 #ifdef WIN32
 #pragma comment(lib, "glew32.lib")
 #endif

--- a/src/cpp/f00300_singleton.hpp
+++ b/src/cpp/f00300_singleton.hpp
@@ -3623,7 +3623,7 @@ public:
 
 
 		if (key == 17) {
-			glutLeaveMainLoop();
+			glutDestroyWindow(glutGetWindow());
 		}
 
 		switch (key) {


### PR DESCRIPTION
Used the suggestion by @netmask for the includes. Also changed `glutLeaveMainLoop()` to `glutDestroyWindow()`. Game is crazy laggy on Mac, virtually unplayable at the moment. Will try to look into this.
